### PR TITLE
Implement Kubernetes Jobs support for long-running scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Phase 2 transforms Security Agency into an intelligent, adaptive, and proactive 
 ---
 
 ## Features
+
 - Modular agent design with a `BaseAgent` class
 - Agents for `nmap`, `nikto`, `sqlmap`, `wpscan`, `sublist3r`, and `dirb`
 - Orchestrator with scheduling, retries, and parallel execution
@@ -39,6 +40,7 @@ Phase 2 transforms Security Agency into an intelligent, adaptive, and proactive 
 ## Installation
 
 ### Using venv
+
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
@@ -46,29 +48,62 @@ pip install -r requirements.txt
 ```
 
 ### Using Poetry
+
 ```bash
 poetry install
 ```
 
 ## Usage
+
 Run the Flask app:
+
 ```bash
 python app.py
 ```
 
 Send a scan request:
+
 ```bash
 curl -X POST http://localhost:5000/scan \
   -H "Content-Type: application/json" \
   -d '{"target": "http://example.com", "agents": ["nmap", "nikto", "sqlmap"]}'
 ```
 
+### Kubernetes Jobs mode (experimental)
+
+For long-running tools, the orchestrator can **schedule Kubernetes Jobs** instead of running tools in-process.
+
+Enable it via environment variables:
+
+- `USE_K8S_JOBS=1` — turn on Job scheduling
+- `K8S_NAMESPACE=security-agency` — namespace to create Jobs in
+- `K8S_JOB_AGENTS=nmap,sqlmap` — which agents should be scheduled as Jobs (comma-separated)
+- `K8S_JOB_IMAGE=security-agency/app:latest` — image used to run the Job (must include this repo code)
+- `K8S_STRICT=1` — if set, fail scans when K8s is unavailable instead of falling back to local execution
+
+You can also request k8s explicitly per scan:
+
+- POST `/scan` JSON field: `"execution_mode": "k8s"`
+
+Job APIs:
+
+- `GET /jobs` — list jobs
+- `GET /jobs/<job_id>` — job status (best-effort live refresh)
+- `GET /jobs/<job_id>/logs` — fetch job logs
+- `POST /jobs/<job_id>/cancel` — delete the underlying K8s Job
+
+Status polling (CronJob-friendly):
+
+- `scripts/poll_k8s_jobs.py`
+
 ## Testing
+
 ```bash
 pytest
 ```
 
 ## Documentation
+
 - See [PHASE_2_ROADMAP.md](PHASE_2_ROADMAP.md) for the exciting Phase 2 vision and roadmap
 - See [PHASE_2_QUICKSTART.md](PHASE_2_QUICKSTART.md) for quick start guide to Phase 2
 - See [implementation_plan.md](implementation_plan.md) for progress tracking
@@ -76,4 +111,5 @@ pytest
 - See `.todo.md` for current phase items
 
 ## License
+
 MIT

--- a/app.py
+++ b/app.py
@@ -3,16 +3,18 @@
 from flask import Flask, Response, jsonify, request, send_from_directory
 
 from core.decision_engine import DecisionEngine
+from core.job_manager import JobManager, KubernetesUnavailableError
 from core.models import ScanRequest
 from core.storage import Storage
 from core.orchestrator import Orchestrator
 from core.recommendation_engine import RecommendationEngine
 
 app = Flask(__name__)
-orchestrator = Orchestrator()
 decision_engine = DecisionEngine()
 recommendation_engine = RecommendationEngine(decision_engine)
 storage = Storage()
+job_manager = JobManager()
+orchestrator = Orchestrator(storage=storage, job_manager=job_manager)
 
 
 @app.route("/scan", methods=["POST"])
@@ -27,11 +29,70 @@ def scan():
         requested_agents=data.get("agents", []),
         priority=data.get("priority", 0),
         workflow_id=data.get("workflow_id"),
+        execution_mode=data.get("execution_mode"),
     )
     import asyncio  # pylint: disable=import-outside-toplevel
 
     results = asyncio.run(orchestrator.run_scan_async(scan_request))
     return jsonify([result.__dict__ for result in results])
+
+
+@app.route("/jobs", methods=["GET"])
+def list_jobs():
+    status = request.args.get("status")
+    request_id = request.args.get("request_id")
+    limit = int(request.args.get("limit", 50))
+    jobs = storage.list_k8s_jobs(status=status, request_id=request_id, limit=limit)
+    return jsonify(jobs)
+
+
+@app.route("/jobs/<job_id>", methods=["GET"])
+def get_job(job_id):
+    job = storage.get_k8s_job(job_id)
+    if not job:
+        return jsonify({"error": "Job not found"}), 404
+
+    # Best-effort refresh for pending/running jobs.
+    if job.get("status") in ("pending", "running"):
+        try:
+            live_status = job_manager.get_job_status(job["k8s_job_name"]).value
+            if live_status != job.get("status"):
+                storage.update_k8s_job_status(job_id, live_status)
+                job["status"] = live_status
+        except KubernetesUnavailableError:
+            # If k8s is not configured, keep DB status.
+            pass
+
+    return jsonify(job)
+
+
+@app.route("/jobs/<job_id>/logs", methods=["GET"])
+def get_job_logs(job_id):
+    job = storage.get_k8s_job(job_id)
+    if not job:
+        return jsonify({"error": "Job not found"}), 404
+
+    try:
+        logs = job_manager.get_job_logs(job["k8s_job_name"], tail_lines=int(request.args.get("tail", 2000)))
+    except KubernetesUnavailableError as e:
+        return jsonify({"error": str(e)}), 503
+
+    return Response(logs, mimetype="text/plain")
+
+
+@app.route("/jobs/<job_id>/cancel", methods=["POST"])
+def cancel_job(job_id):
+    job = storage.get_k8s_job(job_id)
+    if not job:
+        return jsonify({"error": "Job not found"}), 404
+
+    try:
+        job_manager.delete_job(job["k8s_job_name"], cascade=True)
+    except KubernetesUnavailableError as e:
+        return jsonify({"error": str(e)}), 503
+
+    storage.update_k8s_job_status(job_id, "cancelled")
+    return jsonify({"status": "cancelled", "job_id": job_id})
 
 
 @app.route("/workflow/<workflow_id>", methods=["GET"])

--- a/core/job_manager.py
+++ b/core/job_manager.py
@@ -1,0 +1,213 @@
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from core.models import K8sJobStatus
+
+
+class KubernetesUnavailableError(RuntimeError):
+    """Raised when Kubernetes client/config is unavailable but k8s mode is requested."""
+
+
+@dataclass
+class JobCreateResult:
+    job_name: str
+    namespace: str
+
+
+class JobManager:
+    """Thin wrapper around the Kubernetes Batch API for Job-based executions.
+
+    This class is intentionally defensive:
+    - If the kubernetes Python client isn't installed, it can still be imported.
+    - If kubeconfig/in-cluster config can't be loaded, it fails with a clear error.
+
+    The orchestrator/API can treat this as an optional capability.
+    """
+
+    def __init__(self, namespace: Optional[str] = None):
+        self.namespace = namespace or os.getenv("K8S_NAMESPACE", "default")
+        self._enabled = False
+        self._batch_v1 = None
+        self._core_v1 = None
+
+        try:
+            # Lazy import so unit tests and local runs don't require the dependency.
+            from kubernetes import client, config  # type: ignore
+
+            try:
+                config.load_incluster_config()
+            except Exception:  # pylint: disable=broad-exception-caught
+                # Local dev.
+                config.load_kube_config()
+
+            self._batch_v1 = client.BatchV1Api()
+            self._core_v1 = client.CoreV1Api()
+            self._client = client
+            self._enabled = True
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Either dependency missing or config missing.
+            self._enabled = False
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def _require_enabled(self) -> None:
+        if not self._enabled:
+            raise KubernetesUnavailableError(
+                "Kubernetes job execution is not available. Install the 'kubernetes' package "
+                "and ensure kubeconfig/in-cluster config is configured."
+            )
+
+    def create_job(
+        self,
+        *,
+        job_name: str,
+        image: str,
+        command: Optional[List[str]] = None,
+        args: Optional[List[str]] = None,
+        env: Optional[Dict[str, str]] = None,
+        labels: Optional[Dict[str, str]] = None,
+        annotations: Optional[Dict[str, str]] = None,
+        backoff_limit: int = 1,
+        ttl_seconds_after_finished: int = 3600,
+        active_deadline_seconds: Optional[int] = None,
+        cpu_request: Optional[str] = None,
+        cpu_limit: Optional[str] = None,
+        memory_request: Optional[str] = None,
+        memory_limit: Optional[str] = None,
+    ) -> JobCreateResult:
+        self._require_enabled()
+
+        client = self._client
+
+        env_list = []
+        if env:
+            for k, v in env.items():
+                env_list.append(client.V1EnvVar(name=k, value=v))
+
+        resources = None
+        if any([cpu_request, cpu_limit, memory_request, memory_limit]):
+            resources = client.V1ResourceRequirements(
+                requests={
+                    **({"cpu": cpu_request} if cpu_request else {}),
+                    **({"memory": memory_request} if memory_request else {}),
+                },
+                limits={
+                    **({"cpu": cpu_limit} if cpu_limit else {}),
+                    **({"memory": memory_limit} if memory_limit else {}),
+                },
+            )
+
+        container = client.V1Container(
+            name="scan",
+            image=image,
+            command=command,
+            args=args,
+            env=env_list,
+            resources=resources,
+        )
+
+        template = client.V1PodTemplateSpec(
+            metadata=client.V1ObjectMeta(labels=labels, annotations=annotations),
+            spec=client.V1PodSpec(restart_policy="Never", containers=[container]),
+        )
+
+        spec = client.V1JobSpec(
+            template=template,
+            backoff_limit=backoff_limit,
+            ttl_seconds_after_finished=ttl_seconds_after_finished,
+            active_deadline_seconds=active_deadline_seconds,
+        )
+
+        job = client.V1Job(
+            api_version="batch/v1",
+            kind="Job",
+            metadata=client.V1ObjectMeta(name=job_name, labels=labels, annotations=annotations),
+            spec=spec,
+        )
+
+        self._batch_v1.create_namespaced_job(namespace=self.namespace, body=job)
+        return JobCreateResult(job_name=job_name, namespace=self.namespace)
+
+    def get_job_status(self, job_name: str) -> K8sJobStatus:
+        self._require_enabled()
+
+        try:
+            job = self._batch_v1.read_namespaced_job(name=job_name, namespace=self.namespace)
+        except Exception:  # pylint: disable=broad-exception-caught
+            return K8sJobStatus.UNKNOWN
+
+        status = getattr(job, "status", None)
+        if not status:
+            return K8sJobStatus.UNKNOWN
+
+        if getattr(status, "active", 0):
+            return K8sJobStatus.RUNNING
+
+        if getattr(status, "succeeded", 0):
+            return K8sJobStatus.SUCCEEDED
+
+        if getattr(status, "failed", 0):
+            return K8sJobStatus.FAILED
+
+        return K8sJobStatus.PENDING
+
+    def _find_job_pods(self, job_name: str) -> List[str]:
+        self._require_enabled()
+        label_selector = f"job-name={job_name}"
+        pods = self._core_v1.list_namespaced_pod(namespace=self.namespace, label_selector=label_selector)
+        return [p.metadata.name for p in pods.items if p and p.metadata and p.metadata.name]
+
+    def get_job_logs(self, job_name: str, tail_lines: int = 2000) -> str:
+        self._require_enabled()
+
+        pod_names = self._find_job_pods(job_name)
+        if not pod_names:
+            return ""
+
+        # Prefer the newest pod (last in list is usually fine; be defensive).
+        pod_name = pod_names[-1]
+        try:
+            return self._core_v1.read_namespaced_pod_log(
+                name=pod_name,
+                namespace=self.namespace,
+                tail_lines=tail_lines,
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            return ""
+
+    def delete_job(self, job_name: str, cascade: bool = True) -> None:
+        self._require_enabled()
+
+        propagation_policy = "Foreground" if cascade else "Orphan"
+        try:
+            self._batch_v1.delete_namespaced_job(
+                name=job_name,
+                namespace=self.namespace,
+                propagation_policy=propagation_policy,
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            return
+
+    def wait_for_completion(
+        self,
+        job_name: str,
+        timeout_seconds: int = 600,
+        poll_interval_seconds: float = 2.0,
+    ) -> Tuple[K8sJobStatus, float]:
+        """Best-effort helper for tests/scripts."""
+        self._require_enabled()
+
+        start = time.time()
+        while True:
+            status = self.get_job_status(job_name)
+            if status in (K8sJobStatus.SUCCEEDED, K8sJobStatus.FAILED, K8sJobStatus.CANCELLED):
+                return status, time.time() - start
+
+            if time.time() - start >= timeout_seconds:
+                return K8sJobStatus.UNKNOWN, time.time() - start
+
+            time.sleep(poll_interval_seconds)

--- a/core/k8s_job_runner.py
+++ b/core/k8s_job_runner.py
@@ -1,0 +1,62 @@
+"""Entry-point used inside Kubernetes Jobs to execute a single tool run.
+
+The job container should run something like:
+
+  python -m core.k8s_job_runner --agent nmap --target example.com --request-id req-123
+
+This prints a JSON representation of ScanResult to stdout so logs can be collected.
+"""
+
+import argparse
+import json
+import sys
+import time
+
+from agents.nikto_agent import NiktoAgent
+from agents.nmap_agent import NmapAgent
+from agents.sqlmap_agent import SqlmapAgent
+from core.models import ScanResult
+
+
+def _agents():
+    return {
+        "nmap": NmapAgent(),
+        "nikto": NiktoAgent(),
+        "sqlmap": SqlmapAgent(),
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Security Agency Kubernetes Job Runner")
+    parser.add_argument("--agent", required=True, help="Agent/tool name (e.g. nmap, nikto, sqlmap)")
+    parser.add_argument("--target", required=True, help="Target to scan")
+    parser.add_argument("--request-id", required=True, help="Scan request ID")
+    args = parser.parse_args(argv)
+
+    agents = _agents()
+    agent = agents.get(args.agent)
+    if not agent:
+        result = ScanResult(
+            id=f"{args.agent}-result",
+            request_id=args.request_id,
+            agent=args.agent,
+            status="failed",
+            output={"stdout": ""},
+            analysis=None,
+            metadata={"stderr": f"Unknown agent: {args.agent}", "exit_code": 127},
+        )
+        print(json.dumps(result.__dict__))
+        return 127
+
+    start = time.time()
+    scan_result = agent.run(args.target, request_id=args.request_id)
+    # Add a tiny bit of timing metadata for observability.
+    scan_result.metadata = scan_result.metadata or {}
+    scan_result.metadata["duration_seconds"] = round(time.time() - start, 3)
+
+    print(json.dumps(scan_result.__dict__))
+    return 0 if scan_result.status == "completed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/core/models.py
+++ b/core/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Dict, List, Optional
 
 
@@ -17,6 +18,7 @@ class ScanRequest:
     requested_agents: Optional[List[str]] = None
     priority: int = 0
     workflow_id: Optional[str] = None
+    execution_mode: Optional[str] = None  # local | k8s
 
 
 @dataclass
@@ -27,6 +29,35 @@ class ScanResult:
     status: str  # queued, running, completed, failed
     output: Dict[str, Any]
     analysis: Optional[Dict[str, Any]] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class K8sJobStatus(str, Enum):
+    """Lifecycle status for long-running scan execution in Kubernetes."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class K8sJobRecord:
+    """Persistence model for a Kubernetes Job associated with a scan request."""
+
+    id: str
+    request_id: str
+    agent: str
+    target: str
+    k8s_job_name: str
+    namespace: str
+    status: str = K8sJobStatus.PENDING.value
+    created_at: Optional[str] = None
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    error_message: Optional[str] = None
     metadata: Optional[Dict[str, Any]] = None
 
 

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -1,5 +1,10 @@
 import asyncio
 
+import os
+import re
+import uuid
+from datetime import datetime
+
 # import random
 from typing import List
 
@@ -10,7 +15,9 @@ from agents.nmap_agent import NmapAgent
 from agents.sqlmap_agent import SqlmapAgent
 from core.decision_engine import DecisionEngine
 from core.event_queue import EventQueue
+from core.job_manager import JobManager, KubernetesUnavailableError
 from core.models import (
+    K8sJobRecord,
     OrchestrationEvent,
     ScanRequest,
     ScanResult,
@@ -21,7 +28,7 @@ from core.storage import Storage
 
 
 class Orchestrator:  # pylint: disable=too-few-public-methods
-    def __init__(self):
+    def __init__(self, *, storage: Storage = None, job_manager: JobManager = None):
         self.agents = {
             "nmap": NmapAgent(),
             "nikto": NiktoAgent(),
@@ -29,10 +36,34 @@ class Orchestrator:  # pylint: disable=too-few-public-methods
         }
         self.queue = EventQueue()
         self.decision_engine = DecisionEngine()
-        self.storage = Storage()
+        self.storage = storage or Storage()
         self.max_retries = 2
         self.concurrent_limit = 3
         self.semaphore = asyncio.Semaphore(self.concurrent_limit)
+
+        self.job_manager = job_manager or JobManager(namespace=os.getenv("K8S_NAMESPACE"))
+        self.use_k8s_jobs = os.getenv("USE_K8S_JOBS", "0") == "1"
+        self.k8s_job_agents = {
+            a.strip() for a in os.getenv("K8S_JOB_AGENTS", "").split(",") if a.strip()
+        }
+        self.k8s_job_image = os.getenv("K8S_JOB_IMAGE", "security-agency/app:latest")
+        self.k8s_strict = os.getenv("K8S_STRICT", "0") == "1"
+
+    def _now_iso(self) -> str:
+        return datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+    def _safe_job_name(self, raw: str) -> str:
+        # DNS-1123 label: lowercase alphanumerics + '-' up to 63 chars.
+        name = re.sub(r"[^a-z0-9-]+", "-", raw.lower())
+        name = re.sub(r"-+", "-", name).strip("-")
+        return name[:63] if len(name) > 63 else name
+
+    def _should_run_as_k8s_job(self, request: ScanRequest, agent_name: str) -> bool:
+        if not self.use_k8s_jobs:
+            return False
+        if getattr(request, "execution_mode", None) == "k8s":
+            return True
+        return agent_name in self.k8s_job_agents
 
     async def run_scan_async(
         self, request: ScanRequest
@@ -72,13 +103,144 @@ class Orchestrator:  # pylint: disable=too-few-public-methods
         results: List[ScanResult] = []
         self.storage.save_scan_request(request)
 
+        pending_tasks: set = set()
+
         async def execute_step(step: WorkflowStep, retries: int = 0):
             async with self.semaphore:
                 agent = self.agents.get(step.agent)
                 if not agent:
                     return
                 try:
-                    result = await agent.run_async(step.input["target"])
+                    target = step.input["target"]
+
+                    if self._should_run_as_k8s_job(request, step.agent):
+                        # Schedule a Kubernetes Job and return immediately.
+                        job_id = str(uuid.uuid4())
+                        job_name = self._safe_job_name(
+                            f"sa-{step.agent}-{request.id}-{int(datetime.utcnow().timestamp())}"
+                        )
+
+                        job_record = K8sJobRecord(
+                            id=job_id,
+                            request_id=request.id,
+                            agent=step.agent,
+                            target=target,
+                            k8s_job_name=job_name,
+                            namespace=self.job_manager.namespace,
+                            status="pending",
+                            created_at=self._now_iso(),
+                            metadata={"mode": "k8s_job"},
+                        )
+
+                        try:
+                            self.storage.save_k8s_job(job_record)
+                            self.job_manager.create_job(
+                                job_name=job_name,
+                                image=self.k8s_job_image,
+                                command=["python", "-m", "core.k8s_job_runner"],
+                                args=[
+                                    "--agent",
+                                    step.agent,
+                                    "--target",
+                                    target,
+                                    "--request-id",
+                                    request.id,
+                                ],
+                                env={
+                                    "REQUEST_ID": request.id,
+                                    "AGENT": step.agent,
+                                    "TARGET": target,
+                                },
+                                labels={
+                                    "app": "security-agency",
+                                    "scan-request-id": self._safe_job_name(request.id),
+                                    "agent": self._safe_job_name(step.agent),
+                                },
+                            )
+                        except KubernetesUnavailableError as e:
+                            # Either fail (strict) or fall back to local.
+                            if self.k8s_strict or getattr(request, "execution_mode", None) == "k8s":
+                                failed = ScanResult(
+                                    id=f"{step.agent}-job-{job_id}",
+                                    request_id=request.id,
+                                    agent=step.agent,
+                                    status="failed",
+                                    output={"stdout": ""},
+                                    analysis=None,
+                                    metadata={"error": str(e), "mode": "k8s_job"},
+                                )
+                                results.append(failed)
+                                self.storage.save_scan_result(failed)
+                                self.queue.publish(
+                                    OrchestrationEvent(
+                                        id=step.id,
+                                        type="scan_failed",
+                                        payload={"error": str(e)},
+                                    )
+                                )
+                                return
+                        except Exception as e:  # pylint: disable=broad-exception-caught
+                            # Scheduling failed (API error, RBAC, etc). Avoid retries creating multiple jobs.
+                            self.storage.update_k8s_job_status(
+                                job_id,
+                                "failed",
+                                completed_at=self._now_iso(),
+                                error_message=str(e),
+                            )
+                            if self.k8s_strict or getattr(request, "execution_mode", None) == "k8s":
+                                failed = ScanResult(
+                                    id=f"{step.agent}-job-{job_id}",
+                                    request_id=request.id,
+                                    agent=step.agent,
+                                    status="failed",
+                                    output={"stdout": ""},
+                                    analysis=None,
+                                    metadata={
+                                        "job_id": job_id,
+                                        "k8s_job_name": job_name,
+                                        "namespace": self.job_manager.namespace,
+                                        "error": str(e),
+                                        "mode": "k8s_job",
+                                    },
+                                )
+                                results.append(failed)
+                                self.storage.save_scan_result(failed)
+                                self.queue.publish(
+                                    OrchestrationEvent(
+                                        id=step.id,
+                                        type="scan_failed",
+                                        payload={"error": str(e)},
+                                    )
+                                )
+                                return
+
+                        # Scheduled successfully.
+                        scheduled = ScanResult(
+                            id=f"{step.agent}-job-{job_id}",
+                            request_id=request.id,
+                            agent=step.agent,
+                            status="scheduled",
+                            output={"stdout": ""},
+                            analysis=None,
+                            metadata={
+                                "job_id": job_id,
+                                "k8s_job_name": job_name,
+                                "namespace": self.job_manager.namespace,
+                            },
+                        )
+                        results.append(scheduled)
+                        self.storage.save_scan_result(scheduled)
+                        self.queue.publish(
+                            OrchestrationEvent(
+                                id=step.id,
+                                type="scan_completed",
+                                payload={"result": scheduled.__dict__},
+                            )
+                        )
+                        return
+
+                    # Default: local async execution.
+                    result = await agent.run_async(target, request.id)
                     results.append(result)
                     self.storage.save_scan_result(result)
                     self.queue.publish(
@@ -100,15 +262,30 @@ class Orchestrator:  # pylint: disable=too-few-public-methods
                             )
                         )
 
-        while self.queue.size() > 0:
+        # Process until there are no more queued events *and* no running tasks.
+        while self.queue.size() > 0 or pending_tasks:
+            # If we're temporarily out of events, wait for a running task to finish
+            # (it will typically publish scan_completed / scan_failed events).
+            if self.queue.size() == 0 and pending_tasks:
+                done, pending = await asyncio.wait(
+                    pending_tasks,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                pending_tasks = pending
+                # Loop back to consume any events published by completed tasks.
+                continue
+
             event = self.queue.consume()
             if not event:
+                # Avoid tight loop if the queue is momentarily empty.
+                await asyncio.sleep(0)
                 continue
 
             if event.type == "scan_started":
                 step_data = event.payload["step"]
                 step = WorkflowStep(**step_data)
-                asyncio.create_task(execute_step(step))
+                task = asyncio.create_task(execute_step(step))
+                pending_tasks.add(task)
 
             elif event.type == "scan_completed":
                 decision = self.decision_engine.decide_next_steps(workflow, results)
@@ -120,5 +297,10 @@ class Orchestrator:  # pylint: disable=too-few-public-methods
                             payload={"step": next_step.__dict__},
                         )
                     )
+
+            elif event.type == "scan_failed":
+                # Failure is terminal for that step; currently we don't enqueue additional steps.
+                # Hook: future versions could decide escalation/retry workflows here.
+                continue
 
         return results

--- a/core/storage.py
+++ b/core/storage.py
@@ -8,7 +8,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.engine import Engine
 from sqlalchemy.types import TEXT, TypeDecorator
 
-from core.models import ScanRequest, ScanResult, Workflow
+from core.models import K8sJobRecord, ScanRequest, ScanResult, Workflow
 
 
 class SQLiteJSON(TypeDecorator):  # pylint: disable=abstract-method, too-many-ancestors
@@ -46,6 +46,8 @@ class Storage:
 
         self.engine: Engine = create_engine(self.db_url, echo=False, future=True)
         self.metadata = MetaData()
+
+        self._dialect_name = self.engine.dialect.name
 
         # Use SQLiteJSON if using SQLite
         json_type = SQLiteJSON if self.db_url.startswith("sqlite") else JSON
@@ -95,19 +97,58 @@ class Storage:
             Column("metadata", json_type),
         )
 
+        self.k8s_jobs = Table(
+            "k8s_jobs",
+            self.metadata,
+            Column("id", String, primary_key=True),
+            Column("request_id", String),
+            Column("agent", String),
+            Column("target", String),
+            Column("k8s_job_name", String, unique=True),
+            Column("namespace", String),
+            Column("status", String),
+            Column("created_at", String),
+            Column("started_at", String),
+            Column("completed_at", String),
+            Column("error_message", String),
+            Column("metadata", json_type),
+        )
+
         self.metadata.create_all(self.engine)
 
-    def save_workflow(self, workflow: Workflow) -> None:
+    def _upsert(self, table: Table, data: dict, id_column: str = "id"):
+        """Cross-database upsert helper.
+
+        - PostgreSQL: ON CONFLICT DO UPDATE
+        - Others (e.g. SQLite in tests): best-effort insert then update
+        """
         with self.engine.begin() as conn:
-            data = {
-                c.name: getattr(workflow, c.name)
-                for c in self.workflows.columns
-                if hasattr(workflow, c.name)
-            }
-            stmt = insert(self.workflows).values(**data)
-            update_data = {k: v for k, v in data.items() if k != "id"}
-            stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=update_data)
-            conn.execute(stmt)
+            if self._dialect_name == "postgresql":
+                stmt = insert(table).values(**data)
+                update_data = {k: v for k, v in data.items() if k != id_column}
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=[id_column],
+                    set_=update_data,
+                )
+                conn.execute(stmt)
+                return
+
+            # Fallback: insert; if fails, update.
+            try:
+                conn.execute(table.insert().values(**data))
+            except Exception:  # pylint: disable=broad-exception-caught
+                update_data = {k: v for k, v in data.items() if k != id_column}
+                conn.execute(
+                    table.update().where(getattr(table.c, id_column) == data[id_column]).values(**update_data)
+                )
+
+    def save_workflow(self, workflow: Workflow) -> None:
+        data = {
+            c.name: getattr(workflow, c.name)
+            for c in self.workflows.columns
+            if hasattr(workflow, c.name)
+        }
+        self._upsert(self.workflows, data, id_column="id")
 
     def save_scan_request(self, request: ScanRequest) -> None:
         with self.engine.begin() as conn:
@@ -119,16 +160,71 @@ class Storage:
             conn.execute(self.scan_requests.insert().values(**data))
 
     def save_scan_result(self, result: ScanResult) -> None:
+        data = {
+            c.name: getattr(result, c.name)
+            for c in self.scan_results.columns
+            if hasattr(result, c.name)
+        }
+        self._upsert(self.scan_results, data, id_column="id")
+
+    def save_k8s_job(self, job: K8sJobRecord) -> None:
+        data = {
+            c.name: getattr(job, c.name)
+            for c in self.k8s_jobs.columns
+            if hasattr(job, c.name)
+        }
+        self._upsert(self.k8s_jobs, data, id_column="id")
+
+    def update_k8s_job_status(
+        self,
+        job_id: str,
+        status: str,
+        *,
+        started_at: str = None,
+        completed_at: str = None,
+        error_message: str = None,
+        metadata: dict = None,
+    ) -> None:
+        values = {"status": status}
+        if started_at is not None:
+            values["started_at"] = started_at
+        if completed_at is not None:
+            values["completed_at"] = completed_at
+        if error_message is not None:
+            values["error_message"] = error_message
+        if metadata is not None:
+            values["metadata"] = metadata
+
         with self.engine.begin() as conn:
-            data = {
-                c.name: getattr(result, c.name)
-                for c in self.scan_results.columns
-                if hasattr(result, c.name)
-            }
-            stmt = insert(self.scan_results).values(**data)
-            update_data = {k: v for k, v in data.items() if k != "id"}
-            stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=update_data)
-            conn.execute(stmt)
+            conn.execute(
+                self.k8s_jobs.update().where(self.k8s_jobs.c.id == job_id).values(**values)
+            )
+
+    def get_k8s_job(self, job_id: str):
+        with self.engine.begin() as conn:
+            result = conn.execute(self.k8s_jobs.select().where(self.k8s_jobs.c.id == job_id)).first()
+            return dict(result._mapping) if result else None  # pylint: disable=protected-access
+
+    def list_k8s_jobs(self, *, status: str = None, request_id: str = None, limit: int = 50):
+        with self.engine.begin() as conn:
+            stmt = self.k8s_jobs.select().order_by(self.k8s_jobs.c.created_at.desc()).limit(limit)
+            if status:
+                stmt = stmt.where(self.k8s_jobs.c.status == status)
+            if request_id:
+                stmt = stmt.where(self.k8s_jobs.c.request_id == request_id)
+            result = conn.execute(stmt)
+            return [dict(row._mapping) for row in result]  # pylint: disable=protected-access
+
+    def list_active_k8s_jobs(self, limit: int = 200):
+        with self.engine.begin() as conn:
+            stmt = (
+                self.k8s_jobs.select()
+                .where(self.k8s_jobs.c.status.in_(["pending", "running"]))
+                .order_by(self.k8s_jobs.c.created_at.desc())
+                .limit(limit)
+            )
+            result = conn.execute(stmt)
+            return [dict(row._mapping) for row in result]  # pylint: disable=protected-access
 
     def update_workflow_state(self, workflow_id: str, state: str) -> None:
         with self.engine.begin() as conn:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ langchain-community = "^0.3.0"
 langchain-core = "^0.3.0"
 psycopg2-binary = "^2.9.0"
 sqlalchemy = "^2.0.0"
+kubernetes = "^30.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ langchain-openai
 langchain-community
 psycopg2-binary
 sqlalchemy
+kubernetes

--- a/scripts/poll_k8s_jobs.py
+++ b/scripts/poll_k8s_jobs.py
@@ -1,0 +1,47 @@
+"""One-shot poller suitable for running as a Kubernetes CronJob.
+
+It refreshes status for any Storage-tracked jobs in (pending|running).
+
+Usage:
+  python scripts/poll_k8s_jobs.py
+
+Environment:
+  DATABASE_URL   - database connection string
+  K8S_NAMESPACE  - namespace where jobs run
+"""
+
+from datetime import datetime
+
+from core.job_manager import JobManager, KubernetesUnavailableError
+from core.storage import Storage
+
+
+def _now_iso() -> str:
+    return datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+def main() -> int:
+    storage = Storage()
+    job_manager = JobManager()
+
+    if not job_manager.enabled:
+        raise KubernetesUnavailableError(
+            "Kubernetes job execution is not available; poller cannot run."
+        )
+
+    active = storage.list_active_k8s_jobs(limit=500)
+    updated = 0
+
+    for job in active:
+        status = job_manager.get_job_status(job["k8s_job_name"]).value
+        if status != job.get("status"):
+            completed_at = _now_iso() if status in ("succeeded", "failed", "cancelled") else None
+            storage.update_k8s_job_status(job["id"], status, completed_at=completed_at)
+            updated += 1
+
+    print(f"polled={len(active)} updated={updated}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_k8s_jobs.py
+++ b/tests/test_k8s_jobs.py
@@ -1,0 +1,65 @@
+import os
+
+import pytest
+
+os.environ["TESTING"] = "1"
+
+from app import app, orchestrator, storage  # pylint: disable=wrong-import-position
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def test_jobs_list_empty(client):
+    resp = client.get("/jobs")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+
+
+def test_scan_k8s_execution_schedules_job(monkeypatch, client):
+    # Force orchestrator into k8s mode for this test without requiring real kube config.
+    orchestrator.use_k8s_jobs = True
+    orchestrator.k8s_job_agents = {"nmap"}
+
+    class FakeJobManager:
+        namespace = "default"
+
+        def create_job(self, **kwargs):
+            # Simulate successful scheduling.
+            return None
+
+    orchestrator.job_manager = FakeJobManager()
+
+    resp = client.post(
+        "/scan",
+        json={
+            "id": "req-k8s-1",
+            "target": "http://example.com",
+            "agents": ["nmap"],
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert data and data[0]["status"] == "scheduled"
+    assert "metadata" in data[0]
+    assert "job_id" in data[0]["metadata"]
+
+    job_id = data[0]["metadata"]["job_id"]
+
+    # Verify job record persisted.
+    job = storage.get_k8s_job(job_id)
+    assert job is not None
+    assert job["request_id"] == "req-k8s-1"
+    assert job["agent"] == "nmap"
+
+    # GET /jobs/<id> should return persisted job.
+    job_resp = client.get(f"/jobs/{job_id}")
+    assert job_resp.status_code == 200
+    job_data = job_resp.get_json()
+    assert job_data["id"] == job_id


### PR DESCRIPTION
Introduce support for executing long-running scans using Kubernetes Jobs, along with related APIs for job management. This includes enhancements to the orchestrator, new job-related endpoints, and a polling script for job status updates. The changes enable users to schedule scans as Kubernetes Jobs, improving scalability and resource management.